### PR TITLE
Fix "Resprocessed" typo in issue details sidebar

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
@@ -591,7 +591,7 @@ export default function getGroupActivityItem(
         const {oldGroupId, eventCount} = data;
 
         return {
-          title: t('Resprocessed Events'),
+          title: t('Reprocessed Events'),
           message: tct('by [author]. [new-events]', {
             author,
             ['new-events']: (


### PR DESCRIPTION
Fix typo:

<img width="316" alt="Screenshot 2025-05-15 at 15 36 24" src="https://github.com/user-attachments/assets/7238f53e-ffd1-4fb3-8f64-ed5f48b244f6" />
